### PR TITLE
feat(pullRequest): Allow to skip and parse pull request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,38 @@ Type: `function` or `boolean` Default: `function() {}`
 
 What warn function to use. For example, `console.warn.bind(console)` or `grunt.log.writeln`. By default, it's a noop. If it is `true`, it will error if commit cannot be parsed (strict).
 
+##### pullRequestPattern
+
+Type: `regex` or `string` Default: null
+
+Pattern to match pull request or merge request headers. Used to parse GitHub or GitLab like pull requests headers. When a pull request header is parsed, the next line is used for conventionnal header parsing.  This option is disabled by default to avoid breaking changes.
+
+For example, if we have a commit
+
+```
+Merge pull request #1 from user/feature/feature-name
+
+feat(scope): broadcast $destroy event on scope destruction
+```
+
+We can parse it with these options and the default headerPattern :
+
+```js
+{
+  pullRequestPattern: /^Merge pull request #(\d+) from (.*)$/,
+  pullRequestCorrespondence: ['id', 'source']
+}
+```
+
+
+##### pullRequestCorrespondence
+
+Type: `array` of `string` or `string` Default: null
+
+Used to define what capturing group of `pullRequestPattern`.
+
+If it's a `string` it will be converted to an `array` separated by a comma.
+
 ### conventionalCommitsParser.sync(commit, [options])
 
 The sync version. Useful when parsing a single commit. Returns the result.

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ function assignOpts(options) {
     fieldPattern: /^-(.*?)-$/,
     revertPattern: /^Revert\s"([\s\S]*)"\s*This reverts commit (\w*)\./,
     revertCorrespondence: ['header', 'hash'],
-    warn: function() {}
+    warn: function() {},
+    pullRequestPattern: null,
+    pullRequestCorrespondence: null
   }, options);
 
   if (typeof options.headerPattern === 'string') {
@@ -57,6 +59,10 @@ function assignOpts(options) {
 
   if (typeof options.revertCorrespondence === 'string') {
     options.revertCorrespondence = options.revertCorrespondence.split(',');
+  }
+
+  if (typeof options.pullRequestPattern === 'string') {
+    options.pullRequestPattern = new RegExp(options.pullRequestPattern);
   }
 
   return options;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -216,6 +216,7 @@ describe('conventionalCommitsParser', function() {
         noteKeywords: 'BREAKING CHANGES',
         referenceActions: 'fix',
         revertPattern: '^Revert\\s"([\\s\\S]*)"\\s*This reverts commit (\\w*)\\.',
+        pullRequestPattern: '/^Merge pull request #(\\d+) from (.*)$/',
         revertCorrespondence: ' header'
       }))
       .pipe(through.obj(function(chunk, enc, cb) {


### PR DESCRIPTION
When merging pull request on GitHub or merge requests on gitlab,
a merge header is added to the commit message. The new pullRequestPattren
option allow to parse this line and use the next line as conventional changelog header.
