### PR TITLE
fix(regex): make getReferencePartsRegex stricter

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -26,7 +26,7 @@ function getReferencePartsRegex(issuePrefixes) {
     return reNomatch;
   }
 
-  return new RegExp('(?:.*?)??\\s*(\\S*?)??(' + join(issuePrefixes, '|') + ')((?:\\w|-)*\\d+)', 'gi');
+  return new RegExp('(?:.*?)??\\s*([\\w-\\.\\/]*?)??(' + join(issuePrefixes, '|') + ')([\\w-]*\\d+)', 'gi');
 }
 
 function getReferencesRegex(referenceActions) {

--- a/test/regex.spec.js
+++ b/test/regex.spec.js
@@ -162,6 +162,21 @@ describe('regex', function() {
       expect(match[3]).to.equal('1');
     });
 
+    it('should reference an issue in parenthesis', function() {
+      var string = '#27), pinned shelljs to version that works with nyc (#30)';
+      var match = reReferenceParts.exec(string);
+      expect(match[0]).to.equal('#27');
+      expect(match[1]).to.equal(undefined);
+      expect(match[2]).to.equal('#');
+      expect(match[3]).to.equal('27');
+
+      match = reReferenceParts.exec(string);
+      expect(match[0]).to.equal('), pinned shelljs to version that works with nyc (#30');
+      expect(match[1]).to.equal(undefined);
+      expect(match[2]).to.equal('#');
+      expect(match[3]).to.equal('30');
+    });
+
     it('should match reference parts with something else', function() {
       var match = reReferenceParts.exec('something else #1');
       expect(match[0]).to.equal('something else #1');


### PR DESCRIPTION
So for messages like "fix: upgraded dependencies, switched back to angular format (fixes #27), pinned shelljs to version that works with nyc (#30)", "(" will not be treated as a `repository`

For now the part that matches a `repository` is `([\\w-\\.\\/]*?)??` instead of `(\\S*?)??`, which is too loose but I might miss some valid characters here.

Fixes #27

@bcoe @nexdrew are you guys happy with the regex here? Am I missing any characters?
