### PR TITLE
feat: support squash commits

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -18,7 +18,7 @@ function getNotesRegex(noteKeywords) {
     return reNomatch;
   }
 
-  return new RegExp('^\\s*(' + join(noteKeywords, '|') + ')[:\\s]+(.*)', 'i');
+  return new RegExp('\\s*(' + join(noteKeywords, '|') + ')[:\\s]+(.*)', 'i');
 }
 
 function getReferencePartsRegex(issuePrefixes) {

--- a/lib/regex.js
+++ b/lib/regex.js
@@ -18,7 +18,7 @@ function getNotesRegex(noteKeywords) {
     return reNomatch;
   }
 
-  return new RegExp('\\s*(' + join(noteKeywords, '|') + ')[:\\s]+(.*)', 'i');
+  return new RegExp('^[\\s|\\W]*(' + join(noteKeywords, '|') + ')[:\\s]+(.*)', 'i');
 }
 
 function getReferencePartsRegex(issuePrefixes) {

--- a/lib/regex.js
+++ b/lib/regex.js
@@ -18,7 +18,7 @@ function getNotesRegex(noteKeywords) {
     return reNomatch;
   }
 
-  return new RegExp('^[\\s|\\W]*(' + join(noteKeywords, '|') + ')[:\\s]+(.*)', 'i');
+  return new RegExp('^[\\s|*]*(' + join(noteKeywords, '|') + ')[:\\s]+(.*)', 'i');
 }
 
 function getReferencePartsRegex(issuePrefixes) {

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -480,6 +480,36 @@ describe('parser', function() {
       });
     });
 
+    it('should parse important notes that start with any non word characters (asterisks in squash commits)', function() {
+
+      var text = 'Previously multiple template bindings on one element\n' +
+          '(ex. `<div *ngIf=\'..\' *ngFor=\'...\'>`) were allowed but most of the time\n' +
+          'were leading to undesired result. It is possible that a small number\n' +
+          'of applications will see template parse errors that shuld be fixed by\n' +
+          'nesting elements or using `<template>` tags explicitly.\n' +
+          '\n' +
+          'Closes #9462';
+      options.noteKeywords = ['BREAKING CHANGE'];
+      reg = regex(options);
+      var msg = parser(
+          'fix(core): report duplicate template bindings in templates\n' +
+          '\n' +
+          'Fixes #7315\n' +
+          '\n' +
+          '* BREAKING CHANGE:\n' +
+          '\n' +
+          text,
+          options,
+          reg
+      );
+      var expected = {
+        title: 'BREAKING CHANGE',
+        text: text
+      };
+
+      expect(msg.notes[0]).to.eql(expected);
+    });
+
     it('should not treat it as important notes if there are texts after `noteKeywords`', function() {
       options.noteKeywords = ['BREAKING CHANGE'];
       reg = regex(options);

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -481,7 +481,6 @@ describe('parser', function() {
     });
 
     it('should parse important notes that start with asterisks (for squash commits)', function() {
-
       var text = 'Previously multiple template bindings on one element\n' +
           '(ex. `<div *ngIf=\'..\' *ngFor=\'...\'>`) were allowed but most of the time\n' +
           'were leading to undesired result. It is possible that a small number\n' +

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -480,7 +480,7 @@ describe('parser', function() {
       });
     });
 
-    it('should parse important notes that start with any non word characters (asterisks in squash commits)', function() {
+    it('should parse important notes that start with asterisks (for squash commits)', function() {
 
       var text = 'Previously multiple template bindings on one element\n' +
           '(ex. `<div *ngIf=\'..\' *ngFor=\'...\'>`) were allowed but most of the time\n' +


### PR DESCRIPTION
This adds support for squash commits in which commit messages are prefixed with asterisks.  
